### PR TITLE
Update workspace ID to match TFE and TF

### DIFF
--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -28,10 +28,6 @@ func TestAccTFEOrganization_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "email", "admin@company.com"),
 					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "session_timeout_minutes", "20160"),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "session_remember_minutes", "20160"),
-					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "collaborator_auth_policy", "password"),
 				),
 			},
@@ -57,10 +53,6 @@ func TestAccTFEOrganization_update(t *testing.T) {
 						"tfe_organization.foobar", "name", "terraform-test"),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "email", "admin@company.com"),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "session_timeout_minutes", "20160"),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "session_remember_minutes", "20160"),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "collaborator_auth_policy", "password"),
 				),
@@ -126,14 +118,6 @@ func testAccCheckTFEOrganizationAttributes(
 
 		if org.Email != "admin@company.com" {
 			return fmt.Errorf("Bad email: %s", org.Email)
-		}
-
-		if org.SessionTimeout != 20160 {
-			return fmt.Errorf("Bad session timeout minutes: %d", org.SessionTimeout)
-		}
-
-		if org.SessionRemember != 20160 {
-			return fmt.Errorf("Bad session remember minutes: %d", org.SessionRemember)
 		}
 
 		if org.CollaboratorAuthPolicy != tfe.AuthPolicyPassword {

--- a/tfe/resource_tfe_team_access.go
+++ b/tfe/resource_tfe_team_access.go
@@ -55,8 +55,8 @@ func resourceTFETeamAccessCreate(d *schema.ResourceData, meta interface{}) error
 	access := d.Get("access").(string)
 	teamID := d.Get("team_id").(string)
 
-	// Get workspace and organization.
-	workspace, organization, err := unpackWorkspaceID(d.Get("workspace_id").(string))
+	// Get organization and workspace.
+	organization, workspace, err := unpackWorkspaceID(d.Get("workspace_id").(string))
 	if err != nil {
 		return fmt.Errorf("Error unpacking workspace ID: %v", err)
 	}

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -72,8 +72,8 @@ func resourceTFEVariableCreate(d *schema.ResourceData, meta interface{}) error {
 	key := d.Get("key").(string)
 	category := d.Get("category").(string)
 
-	// Get workspace and organization.
-	workspace, organization, err := unpackWorkspaceID(d.Get("workspace_id").(string))
+	// Get organization and workspace.
+	organization, workspace, err := unpackWorkspaceID(d.Get("workspace_id").(string))
 	if err != nil {
 		return fmt.Errorf("Error unpacking workspace ID: %v", err)
 	}
@@ -109,8 +109,8 @@ func resourceTFEVariableCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceTFEVariableRead(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	// Get workspace and organization.
-	workspace, organization, err := unpackWorkspaceID(d.Get("workspace_id").(string))
+	// Get organization and workspace.
+	organization, workspace, err := unpackWorkspaceID(d.Get("workspace_id").(string))
 	if err != nil {
 		return fmt.Errorf("Error unpacking workspace ID: %v", err)
 	}

--- a/tfe/resource_tfe_variable_test.go
+++ b/tfe/resource_tfe_variable_test.go
@@ -102,8 +102,8 @@ func testAccCheckTFEVariableExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		// Get the workspace and organization.
-		workspace, organization, err := unpackWorkspaceID(rs.Primary.Attributes["workspace_id"])
+		// Get organization and workspace.
+		organization, workspace, err := unpackWorkspaceID(rs.Primary.Attributes["workspace_id"])
 		if err != nil {
 			return fmt.Errorf("Error unpacking workspace ID: %v", err)
 		}
@@ -200,8 +200,8 @@ func testAccCheckTFEVariableDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		// Get the workspace and organization.
-		workspace, organization, err := unpackWorkspaceID(rs.Primary.Attributes["workspace_id"])
+		// Get organization and workspace.
+		organization, workspace, err := unpackWorkspaceID(rs.Primary.Attributes["workspace_id"])
 		if err != nil {
 			return fmt.Errorf("Error unpacking workspace ID: %v", err)
 		}

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -144,8 +144,8 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	// Get the name and organization.
-	name, organization, err := unpackWorkspaceID(d.Id())
+	// Get the organization and workspace name.
+	organization, name, err := unpackWorkspaceID(d.Id())
 	if err != nil {
 		return fmt.Errorf("Error unpacking workspace ID: %v", err)
 	}
@@ -200,8 +200,8 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	// Get the name and organization.
-	name, organization, err := unpackWorkspaceID(d.Id())
+	// Get the organization and workspace name.
+	organization, name, err := unpackWorkspaceID(d.Id())
 	if err != nil {
 		return fmt.Errorf("Error unpacking workspace ID: %v", err)
 	}
@@ -256,8 +256,8 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 func resourceTFEWorkspaceDelete(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	// Get the name and organization.
-	name, organization, err := unpackWorkspaceID(d.Id())
+	// Get the organization and workspace name.
+	organization, name, err := unpackWorkspaceID(d.Id())
 	if err != nil {
 		return fmt.Errorf("Error unpacking workspace ID: %v", err)
 	}
@@ -279,13 +279,19 @@ func packWorkspaceID(w *tfe.Workspace) (id string, err error) {
 	if w.Organization == nil {
 		return "", fmt.Errorf("no organization in workspace response")
 	}
-	return w.Name + "|" + w.Organization.Name, nil
+	return w.Organization.Name + "/" + w.Name, nil
 }
 
-func unpackWorkspaceID(id string) (name, organization string, err error) {
-	s := strings.SplitN(id, "|", 2)
+func unpackWorkspaceID(id string) (organization, name string, err error) {
+	// Support the old ID format for backwards compatibitily.
+	if s := strings.SplitN(id, "|", 2); len(s) == 2 {
+		return s[1], s[0], nil
+	}
+
+	s := strings.SplitN(id, "/", 2)
 	if len(s) != 2 {
 		return "", "", fmt.Errorf("invalid workspace ID format: %s", id)
 	}
+
 	return s[0], s[1], nil
 }

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -92,8 +92,8 @@ func testAccCheckTFEWorkspaceExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		// Get the name and organization.
-		name, organization, err := unpackWorkspaceID(rs.Primary.ID)
+		// Get the organization and workspace name.
+		organization, name, err := unpackWorkspaceID(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Error unpacking workspace ID: %v", err)
 		}
@@ -103,7 +103,7 @@ func testAccCheckTFEWorkspaceExists(
 			return err
 		}
 
-		id, err := packWorkspaceID(workspace)
+		id, err := packWorkspaceID(w)
 		if err != nil {
 			return fmt.Errorf("Error creating ID for workspace %s: %v", name, err)
 		}
@@ -172,8 +172,8 @@ func testAccCheckTFEWorkspaceDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		// Get the name and organization.
-		name, organization, err := unpackWorkspaceID(rs.Primary.ID)
+		// Get the organization and workspace name.
+		organization, name, err := unpackWorkspaceID(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Error unpacking workspace ID: %v", err)
 		}


### PR DESCRIPTION
In TFE a workspace is usually presented as `organization/workspace`.

And if you want to `force-unlock` a remote state (a workspace) in TF, you have to pass `organization/workspace` as the lock ID.

So it makes sense to use the same format as the internal ID for a workspace in the `tfe_workspace` resource. Espacially when we are adding imports, as then people are required to pass that ID to the import command.